### PR TITLE
Unsuccessful/caching not witness status

### DIFF
--- a/src/algorithm/datastructure/mod.rs
+++ b/src/algorithm/datastructure/mod.rs
@@ -1288,6 +1288,13 @@ where
         } else {
             WitnessStatus::WitnessUniquenessDecided(WitnessUniqueness::NotUnique)
         };
+
+        // actually this cache doesn't seem to improve the performance.
+        // in some cases, the performance drops by a few percents,
+        // in other, it increases by the same amount.
+        // Overall, not a reasonable improvement, considering a mess
+        // it introduced with types for witness statuses
+
         // cache result
         self.witnesses
             .lock()

--- a/src/algorithm/datastructure/tests/mod.rs
+++ b/src/algorithm/datastructure/tests/mod.rs
@@ -744,7 +744,7 @@ fn test_round_indices_consistent() {
 fn test_determine_witness() {
     run_tests!(
         tested_function_name => "determine_witness",
-        tested_function => |graph, event| graph.determine_witness(&event).expect(&format!("Can't find event {:?}", event)),
+        tested_function => |graph, event| graph.is_witness(&event).expect(&format!("Can't find event {:?}", event)),
         name_lookup => |names, event| names.get(event).unwrap().to_owned(),
         peers_literal => peers,
         tests => [


### PR DESCRIPTION
Actually this cache doesn't seem to improve the performance.
In some cases, the performance drops by a few percents, in other, it increases by the same amount.
Overall, not a reasonable improvement, considering a mess it introduced with types for witness statuses.

It makes sense, since inside `is_unique_famous_witness` already uses cached `is_famous_witness` and it checks only events from a single round